### PR TITLE
refactor: validate parameters and the returns of functions in graphs.py (#606)

### DIFF
--- a/dataprofiler/reports/utils.py
+++ b/dataprofiler/reports/utils.py
@@ -1,9 +1,14 @@
 """Contains functions for checking for installations/dependencies."""
 import sys
 import warnings
+from typing import List, Callable, TypeVar, cast, Any
+from typing import NoReturn
+
+#Generic type for the return of the function "require_module()"
+F = TypeVar('F', bound=Callable[..., Any])
 
 
-def warn_missing_module(graph_func, module_name):
+def warn_missing_module(graph_func: str, module_name: str) -> NoReturn:
     """
     Return a warning if a given graph module doesn't exist.
 
@@ -21,7 +26,8 @@ def warn_missing_module(graph_func, module_name):
     warnings.warn(warning_msg, RuntimeWarning, stacklevel=3)
 
 
-def require_module(names):
+
+def require_module(names: List[str]) -> F:
     """
     Check if a set of modules exists in sys.modules prior to running function.
 
@@ -32,7 +38,7 @@ def require_module(names):
     :type names: list[str]
     """
 
-    def check_module(f):
+    def check_module(f: F) -> F:
         def new_f(*args, **kwds):
             for module_name in names:
                 if module_name not in sys.modules.keys():
@@ -46,6 +52,6 @@ def require_module(names):
             return f(*args, **kwds)
 
         new_f.__name__ = f.__name__
-        return new_f
+        return cast(F, new_f)
 
-    return check_module
+    return cast(F, check_module)


### PR DESCRIPTION
Imports additions to validate the types of functions' parameters and its returns using mypy:
--> Line 8: from typing import Union, List

Other changes:
--> Line 24: add the return type as plt.figure and the following types for the parameters: 
profiler: StructuredProfiler, 
column_names: List[Union[int,str]] = None, 
column_inds: List[int] = None
--> Line 78: add the return type as bool
--> Line 137: add the return type as matplotlib.axes and the following types for the parameters: 
data_type_profiler: Union[int, float], 
ax: matplotlib.axes.Axes=None, 
title: str=None
--> Line 171: add the return type as matplotlib.figure and the following types for the parameters: 
profiler: StructuredProfiler, 
ax: matplotlib.axes.Axes=None, 
title: str=None
--> Line 191: add the return type as matplotlib.figure and the following types for the parameters: 
col_profiler_list: List[StructuredColProfiler], 
ax: matplotlib.axes.Axes=None, 
title: str=None
